### PR TITLE
Serialise relative paths for model source files

### DIFF
--- a/src/opencmiss/neon/core/mainapplication.py
+++ b/src/opencmiss/neon/core/mainapplication.py
@@ -69,7 +69,10 @@ class MainApplication(object):
         self._document = NeonDocument()
 
     def save(self):
-        dictOutput = self._document.serialize()
+        # make model sources relative to current location if possible
+        # note that sources on different windows drives have absolute paths
+        basePath = os.path.dirname(self._location)
+        dictOutput = self._document.serialize(basePath)
         with open(self._location, 'w') as f:
             f.write(json.dumps(dictOutput, default=lambda o: o.__dict__, sort_keys=True, indent=2))
 

--- a/src/opencmiss/neon/core/neondocument.py
+++ b/src/opencmiss/neon/core/neondocument.py
@@ -74,11 +74,11 @@ class NeonDocument(object):
             pass
         return result
 
-    def serialize(self):
+    def serialize(self, basePath=None):
         outputVersion = [mainsettings.VERSION_MAJOR, mainsettings.VERSION_MINOR, mainsettings.VERSION_PATCH]
         dictOutput = {}
         dictOutput["OpenCMISS-Neon Version"] = outputVersion
-        dictOutput["RootRegion"] = self._rootRegion.serialize()
+        dictOutput["RootRegion"] = self._rootRegion.serialize(basePath)
         return dictOutput
 
     def getZincContext(self):

--- a/src/opencmiss/neon/core/neonmodelsources.py
+++ b/src/opencmiss/neon/core/neonmodelsources.py
@@ -17,6 +17,11 @@ import os
 from opencmiss.zinc.streamregion import StreaminformationRegion
 
 
+def fileNameToRelativePath(fileName, basePath):
+    if (basePath is None) or (not os.path.isabs(fileName)) or (os.path.commonprefix([fileName, basePath]) == ""):
+        return fileName
+    return os.path.relpath(fileName, basePath)
+
 class NeonModelSourceFile(object):
 
     def __init__(self, fileName=None, dictInput=None):
@@ -38,7 +43,7 @@ class NeonModelSourceFile(object):
         if not self._fileName:
             self._edit = True
             return
-        resource = streamInfo.createStreamresourceFile(self._fileName)
+        resource = streamInfo.createStreamresourceFile(str(self._fileName))
         self._loaded = True
         if self._time is not None:
             streamInfo.setResourceAttributeReal(resource, StreaminformationRegion.ATTRIBUTE_TIME, self._time)
@@ -78,7 +83,8 @@ class NeonModelSourceFile(object):
         self._edit = edit
 
     def _deserialize(self, dictInput):
-        self._fileName = str(dictInput["FileName"])
+        # convert to absolute file path so can save Neon file to new location and get correct relative path
+        self._fileName = os.path.abspath(dictInput["FileName"])
         if "Time" in dictInput:
             self._time = dictInput["Time"]
         if "Format" in dictInput:
@@ -86,10 +92,10 @@ class NeonModelSourceFile(object):
         if "Edit" in dictInput:
             self._edit = dictInput["Edit"]
 
-    def serialize(self):
+    def serialize(self, basePath=None):
         dictOutput = {}
         dictOutput["Type"] = self.getType()
-        dictOutput["FileName"] = self._fileName
+        dictOutput["FileName"] = fileNameToRelativePath(self._fileName, basePath)
         if self._time is not None:
             dictOutput["Time"] = self._time
         if self._edit:

--- a/src/opencmiss/neon/core/neonregion.py
+++ b/src/opencmiss/neon/core/neonregion.py
@@ -43,6 +43,13 @@ class NeonRegion(object):
         for child in self._children:
             child.freeContents()
 
+    def _createBlankCopy(self):
+        zincRegion = self._zincRegion.createRegion()
+        if self._name:
+            zincRegion.setName(self._name)
+        blankRegion = NeonRegion(self._name, zincRegion, self._parent)
+        return blankRegion
+
     def _assign(self, source):
         """
         Replace contents of self with that of source. Fixes up Zinc parent/child region relationships.
@@ -126,13 +133,6 @@ class NeonRegion(object):
             self._assign(tmpRegion)
             self._informRegionChange(True)
 
-    def _createBlankCopy(self):
-        zincRegion = self._zincRegion.createRegion()
-        if self._name:
-            zincRegion.setName(self._name)
-        blankRegion = NeonRegion(self._name, zincRegion, self._parent)
-        return blankRegion
-
     def _discoverNewZincRegions(self):
         """
         Ensure there are Neon regions for every Zinc Region in tree
@@ -204,7 +204,7 @@ class NeonRegion(object):
                 neonChild.deserialize(dictChild)
         self._discoverNewZincRegions()
 
-    def serialize(self):
+    def serialize(self, basePath=None):
         dictOutput = {}
         if self._name:
             dictOutput["Name"] = self._name
@@ -212,7 +212,7 @@ class NeonRegion(object):
         if self._modelSources:
             tmpOutput = []
             for modelSource in self._modelSources:
-                tmpOutput.append(modelSource.serialize())
+                tmpOutput.append(modelSource.serialize(basePath))
             dictOutput["Model"]["Sources"] = tmpOutput
         if not dictOutput["Model"]:
             dictOutput.pop("Model")
@@ -223,7 +223,7 @@ class NeonRegion(object):
         if self._children:
             tmpOutput = []
             for child in self._children:
-                tmpOutput.append(child.serialize())
+                tmpOutput.append(child.serialize(basePath))
             dictOutput["ChildRegions"] = tmpOutput
         return dictOutput
 

--- a/src/opencmiss/neon/ui/editors/modelsourceseditorwidget.py
+++ b/src/opencmiss/neon/ui/editors/modelsourceseditorwidget.py
@@ -189,7 +189,7 @@ class ModelSourcesEditorWidget(QtGui.QWidget):
         # fileFilter = fileNameTuple[1]
         if not fileName:
             return
-        self._currentModelSource.setFileName(str(fileName))
+        self._currentModelSource.setFileName(fileName)
         self._editedCurrentModelSource()
         # set current directory to path from file, to support scripts and fieldml with external resources
         self._fileNameDisplay()


### PR DESCRIPTION
Relative paths are used even if model file is not under directory tree starting at .neon file location.
File paths on different Windows drives from .neon file always use absolute path.
Note while in memory file paths are absolute.
