### PR TITLE
Make scene viewers use a white background

### DIFF
--- a/src/opencmiss/neon/core/neondocument.py
+++ b/src/opencmiss/neon/core/neondocument.py
@@ -18,6 +18,7 @@ from opencmiss.neon.core.neonregion import NeonRegion
 from opencmiss.neon.core.neonspectrums import NeonSpectrums
 from opencmiss.neon.core.neontessellations import NeonTessellations
 from opencmiss.zinc.context import Context
+from opencmiss.zinc.material import Material
 from opencmiss.neon.core.neonlogger import NeonLogger
 
 class NeonDocument(object):
@@ -25,9 +26,21 @@ class NeonDocument(object):
     def __init__(self):
         self._zincContext = Context("Neon")
 
+        sceneviewermodule = self._zincContext.getSceneviewermodule()
+        sceneviewermodule.setDefaultBackgroundColourRGB([1.0, 1.0, 1.0])
+
         # set up standard materials and glyphs
         materialmodule = self._zincContext.getMaterialmodule()
+        materialmodule.beginChange()
         materialmodule.defineStandardMaterials()
+        # make default material black
+        defaultMaterial = materialmodule.getDefaultMaterial()
+        defaultMaterial.setAttributeReal3(Material.ATTRIBUTE_AMBIENT, [0.0, 0.0, 0.0])
+        defaultMaterial.setAttributeReal3(Material.ATTRIBUTE_DIFFUSE, [0.0, 0.0, 0.0])
+        # still want surfaces to default to white material
+        white = materialmodule.findMaterialByName("white")
+        materialmodule.setDefaultSurfaceMaterial(white)
+        materialmodule.endChange()
         glyphmodule = self._zincContext.getGlyphmodule()
         glyphmodule.defineStandardGlyphs()
 
@@ -80,7 +93,7 @@ class NeonDocument(object):
             NeonLogger.getLogger().error("Exception in NeonDocument.deserialize")
             result = False
         finally:
-            # zincRegion.endChange() see zincRegion.beginHierarchicalChange()
+            # zincRegion.endHierarchicalChange() - see above why this can't be done yet
             pass
         return result
 


### PR DESCRIPTION
This is a better default (than white on black) for an application aimed to produce images for publications.
